### PR TITLE
12 comment count added to articles response. 

### DIFF
--- a/__tests__/app.tests.js
+++ b/__tests__/app.tests.js
@@ -764,25 +764,5 @@ describe("nc news app", () => {
           });
         });
     });
-    test("status: 404, responds with an error message if the article id is not found, but is a valid number", () => {
-      return request(app)
-        .get("/api/articles/999")
-        .expect(404)
-        .then(({ body }) => {
-          expect(body).toEqual({
-            msg: "Article not found",
-          });
-        });
-    });
-    test("status: 400, responds with an error message if the article id is not a number", () => {
-      return request(app)
-        .get("/api/articles/not-a-number")
-        .expect(400)
-        .then(({ body }) => {
-          expect(body).toEqual({
-            msg: "Bad Request",
-          });
-        });
-    });
   });
 });

--- a/__tests__/app.tests.js
+++ b/__tests__/app.tests.js
@@ -713,4 +713,56 @@ describe("nc news app", () => {
       });
     });
   });
+  describe("GET /api/articles/:article_id UPDATE (comment count)", () => {
+    test("status: 200, responds with an object containing a key of 'article' and a value of an object which now also has a 'comment_count' key with the correct value", () => {
+      return request(app)
+        .get("/api/articles/1")
+        .expect(200)
+        .then(({ body }) => {
+          expect(Object.keys(body)[0]).toBe("article");
+          expect(body.article).toBeInstanceOf(Object);
+          expect(body.article).toMatchObject({
+            comment_count: expect.any(Number),
+          });
+        });
+    });
+    test("status: 200, responds with the correct article details matched with the article that has the id of 1 and also now has COMMENT COUNT", () => {
+      return request(app)
+        .get("/api/articles/1")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.article).toMatchObject({
+            article_id: 1,
+            author: "butter_bridge",
+            title: "Living in the shadow of a great man",
+            body: "I find this existence challenging",
+            topic: "mitch",
+            created_at: "2020-07-09T20:11:00.000Z",
+            votes: 100,
+            article_img_url:
+              "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+            comment_count: 11,
+          });
+        });
+    });
+    test("status: 200, responds with the correct article details matched with the article that has the id of 7 and also now has COMMENT COUNT", () => {
+      return request(app)
+        .get("/api/articles/7")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.article).toMatchObject({
+            article_id: 7,
+            author: "icellusedkars",
+            title: "Z",
+            body: "I was hungry.",
+            topic: "mitch",
+            created_at: "2020-01-07T14:08:00.000Z",
+            votes: 0,
+            article_img_url:
+              "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+            comment_count: 0,
+          });
+        });
+    });
+  });
 });

--- a/__tests__/app.tests.js
+++ b/__tests__/app.tests.js
@@ -764,5 +764,25 @@ describe("nc news app", () => {
           });
         });
     });
+    test("status: 404, responds with an error message if the article id is not found, but is a valid number", () => {
+      return request(app)
+        .get("/api/articles/999")
+        .expect(404)
+        .then(({ body }) => {
+          expect(body).toEqual({
+            msg: "Article not found",
+          });
+        });
+    });
+    test("status: 400, responds with an error message if the article id is not a number", () => {
+      return request(app)
+        .get("/api/articles/not-a-number")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body).toEqual({
+            msg: "Bad Request",
+          });
+        });
+    });
   });
 });

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -41,9 +41,12 @@ exports.fetchArticleById = (article_id) => {
   return db
     .query(
       `
-    SELECT *
+    SELECT articles.*, CAST(count(comments.comment_id)AS INTEGER) AS comment_count
     FROM articles
+    LEFT JOIN comments
+    ON articles.article_id = comments.article_id
     WHERE articles.article_id = $1
+    GROUP BY articles.article_id
         `,
       [article_id]
     )


### PR DESCRIPTION
Get request to /api/articles/:article_id now also responds with a comment count. Error tests redone to ensure they still work.